### PR TITLE
Use template method

### DIFF
--- a/src/InertiaStatamic.php
+++ b/src/InertiaStatamic.php
@@ -25,7 +25,7 @@ class InertiaStatamic
     {
         $page = app(FrontendController::class)->index($request);
 
-        if ($page->augmentedValue('template') === 'app' && ($page instanceof Page || $page instanceof Entry)) {
+        if ($page->template() === 'app' && ($page instanceof Page || $page instanceof Entry)) {
             return Inertia::render(
                 $this->buildComponentPath($page),
                 $this->buildProps($page)

--- a/src/InertiaStatamic.php
+++ b/src/InertiaStatamic.php
@@ -25,7 +25,7 @@ class InertiaStatamic
     {
         $page = app(FrontendController::class)->index($request);
 
-        if ($page->template() === 'app' && ($page instanceof Page || $page instanceof Entry)) {
+        if (($page instanceof Page || $page instanceof Entry) && $page->template() === 'app') {
             return Inertia::render(
                 $this->buildComponentPath($page),
                 $this->buildProps($page)


### PR DESCRIPTION
Disclaimer - I did this all in the GitHub editor. I didn't actually test it, so you'll probably want to check it out.

While I was doing https://github.com/statamic/cms/pull/5302 for Statamic 3.3, I went looking on GitHub for usages of `augmentValue()` and noticed this.

1. On Statamic 3.2, if you had a field in your blueprint named `template`, `$this->augmentedValue('template')` would have been a `Value` instance, so this condition would always be `false`.
2. On Statamic 3.3, even if you don't have a field named `template`, `$this->augmentedValue('template')` will be a `Value` instance, again making this condition always `false`.
3. You can just use the `template()` method to get the plain template name.
4. I swapped the `instanceof` check to first, so you can be sure the `template()` method will be available to use since you'll know it's a `Page` or `Entry` already.